### PR TITLE
Remove kvstore_Sipsettings update that breake backup restore

### DIFF
--- a/freepbx.spec
+++ b/freepbx.spec
@@ -12,6 +12,7 @@ Source2:	music.tar.gz
 Source3:	dahdi-blacklist.conf
 
 Patch0: 	version_fix.patch
+Patch1: 	restore_data.patch
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}
 BuildArch: 	noarch
@@ -50,6 +51,7 @@ rm -rf %{buildroot}
 %setup -q -n %{name}
 
 %patch0 -p1
+%patch1 -p1
 
 %build
 

--- a/restore_data.patch
+++ b/restore_data.patch
@@ -1,0 +1,12 @@
+diff -Naur a/amp_conf/htdocs/admin/modules/sipsettings/install.php b/amp_conf/htdocs/admin/modules/sipsettings/install.php
+--- a/amp_conf/htdocs/admin/modules/sipsettings/install.php	2019-09-26 06:45:39.000000000 +0200
++++ b/amp_conf/htdocs/admin/modules/sipsettings/install.php	2022-07-08 18:07:07.580972264 +0200
+@@ -112,8 +112,6 @@
+ } else {
+ 	out(_("already exists"));
+ }
+-//let update the kvstore
+-sql("UPDATE kvstore_Sipsettings SET type='json-arr' WHERE `key` ='pjsip_identifers_order'");
+ //OK let's do some migrating for BMO
+ $ss = FreePBX::Sipsettings();
+ if(!$ss->getConfig('rtpstart') || !$ss->getConfig('rtpend')) {


### PR DESCRIPTION
The update in the Sipsettings installation doesn't break anything at first install because kvstore_Sipsettings doesn't have pjsip_identifers_order row, but on restore, the module isn't installed, so the install script is executed, but the table contains the row and the UPDATE breaks the module
https://github.com/nethesis/dev/issues/6172